### PR TITLE
Enable OpenGL for Wayland

### DIFF
--- a/wayland.nix
+++ b/wayland.nix
@@ -3,4 +3,5 @@
   environment.systemPackages = with pkgs; [
     weston
   ];
+  hardware.opengl.enable = true;
 }


### PR DESCRIPTION
The opengl support is added for Wayland which is suggested by @humaidtii.
Resolves mikatammi/ghafhack#2